### PR TITLE
Fix example API URL

### DIFF
--- a/ckanext/iati/theme/templates/static/registry-api.html
+++ b/ckanext/iati/theme/templates/static/registry-api.html
@@ -19,7 +19,7 @@
 
   <p>To fetch activity files:</p>
 
-  <p><a href="http://iatiregistry.org/api/3/action/package_search?q=extras_filetype:activity/%25s/iati2.staging.ckanhosted.com/iatiregistry.org/g/%25s/iati2.staging.ckanhosted.com/iatiregistry.org/g">http://iatiregistry.org/api/3/action/package_search?q=extras_filetype:activity</a></p>
+  <p><a href="http://iatiregistry.org/api/3/action/package_search?q=extras_filetype:activity">http://iatiregistry.org/api/3/action/package_search?q=extras_filetype:activity</a></p>
 
   <p>These calls will not return all results by default. Page through results with the offset and limit parameters. For example:</p>
 


### PR DESCRIPTION
Make the link href match the anchor text.

This looks like it was a regex substitution typo, introduced in 7ce99d7b.