### PR TITLE
Update links to new website

### DIFF
--- a/ckanext/iati/theme/templates/organization/snippets/organization_form.html
+++ b/ckanext/iati/theme/templates/organization/snippets/organization_form.html
@@ -19,13 +19,13 @@
     <p class="help-block">The Name of the Organisation publishing the data.</p>
 
     {{ form.input('publisher_iati_id', label=_('IATI Organisation Identifier (required) *'), id='field-publisher_iati_id', value=data.publisher_iati_id, error=errors.publisher_iati_id) }}
-    <p class="help-block">The organisation identifier used in the IATI XML files to identify the reporting organisation. For more information please go to <a href="http://iatistandard.org/guidance/how-to-publish/iati-organisation-identifiers">http://iatistandard.org/guidance/how-to-publish/iati-organisation-identifiers</a>.</p>
+    <p class="help-block">The organisation identifier used in the IATI XML files to identify the reporting organisation. For more information please go to <a href="http://iatistandard.org/en/guidance/preparing-organisation/organisation-account/how-to-create-your-iati-organisation-identifier/">How to create your IATI organisation identifier</a>.</p>
 
     {{ select('publisher_source_type', label=_('Source'), data=data) }}
     <p class="help-block">Primary - publishers authorised to report their own (or associated organisations') data. Secondary - publishers reporting the activities of other organisations.</p>
 
     {{ select('license_id', label=_('License'), data=data, autocomplete=true) }}
-    <p class="help-block">Choose from the dropdown the appropriate licence under which your data is being published. For more information on IATI's licensing guidelines go to <a href="http://iatistandard.org/guidance/how-to-publish/licensing/">http://iatistandard.org/guidance/how-to-publish/licensing/</a>.</p>
+    <p class="help-block">Choose from the dropdown the appropriate licence under which your data is being published. For more information on IATI's licensing guidelines go to <a href="http://iatistandard.org/en/guidance/preparing-organisation/organisation-data-publication/how-to-license-you-data/">How to license your data</a>.</p>
 
     {{ select('publisher_organization_type', label=_('Type'), data=data) }}
     <p class="help-block">Choose from the dropdown the organisation type that best describes the publisher.</p>


### PR DESCRIPTION
Updating links to 'How to create your IATI Organisation ID' and 'How to license your data'.

Both of these are now on the new IATI website