### PR TITLE
Replace CSV Converter links with datastore links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,7 +84,7 @@ like ``ckan.site_id``, ``solr_url``, etc are not included)::
     # File preview service URL and CSV export service URL.
     # If these are commented out, the links won't appear in the frontend
     iati.preview_service = http://tools.aidinfolabs.org/showmydata/index.php?url=%s
-    iati.csv_service = http://tools.aidinfolabs.org/csv/direct_from_registry/?xml=%s
+    iati.csv_service = http://datastore.iatistandard.org/api/1/access/activity.csv?registry-dataset=%s
 
     # User name and API key for the iati-archiver sysadmin user
     iati.admin_user.name=iati-archiver

--- a/ckanext/iati/theme/templates/snippets/resource_links.html
+++ b/ckanext/iati/theme/templates/snippets/resource_links.html
@@ -22,7 +22,7 @@
 {% set is_org_file = (h.get_pkg_dict_extra(package, 'filetype') == 'organisation') %}
 {% if h.get_config_option('iati.csv_service') and not is_org_file %}
   &middot;
-  <a href="{{ h.get_config_option('iati.csv_service') % h.urlencode(resource.url) }}" {% if show_buttons %} class="btn"{% endif %} target="_blank">
+  <a href="{{ h.get_config_option('iati.csv_service') % resource.name }}" {% if show_buttons %} class="btn"{% endif %} target="_blank">
     {% if show_buttons %}<i class="icon-external-link"></i> CSV{% endif %}
     {% if not show_buttons %}CSV <i class="icon-external-link"></i>{% endif %}
   </a>


### PR DESCRIPTION
Links to the CSVConverter c/should point to the datastore instead.

This PR requires an update to a local ini file, reflected in the update to the README. It also requires some thorough testing.