### PR TITLE
Make "edit publisher" fields readonly instead of disabled

### DIFF
--- a/ckanext/iati/logic/validators.py
+++ b/ckanext/iati/logic/validators.py
@@ -207,7 +207,7 @@ def _check_access_to_change_ids(key, data, group, user):
     if isinstance(key, tuple):
         key = key[0]
 
-    if key =='publisher_iati_id':
+    if key == 'publisher_iati_id':
         val = group.extras.get('publisher_iati_id', '')
     else:
         val = group.name
@@ -227,7 +227,3 @@ def change_publisher_id_or_org_id(key, data, errors, context):
         if not _check_access_to_change_ids(key, data, group, user):
             errors[key].append('Only system administrators can change this ' +
                                'field for an active publisher.')
-
-
-
-

--- a/ckanext/iati/logic/validators.py
+++ b/ckanext/iati/logic/validators.py
@@ -225,8 +225,8 @@ def change_publisher_id_or_org_id(key, data, errors, context):
 
     if group:
         if not _check_access_to_change_ids(key, data, group, user):
-            errors[key].append('Only system admin can change this {} for an active dataset.'.format(key[0]))
-
+            errors[key].append('Only system administrators can change this ' +
+                               'field for an active publisher.')
 
 
 

--- a/ckanext/iati/theme/templates/organization/snippets/organization_form.html
+++ b/ckanext/iati/theme/templates/organization/snippets/organization_form.html
@@ -15,7 +15,7 @@
     {% if c.userobj.sysadmin or data.state != 'active' %}
       {% set attrs = {} %}
     {% else %}
-      {% set attrs = {'disabled':"disabled"} %}
+      {% set attrs = {'readonly':"readonly"} %}
     {% endif %}
 
     {{ form.input('name', label=_('Publisher Id (required) *'), id='field-name', value=data.name, error=errors.name, attrs=attrs) }}


### PR DESCRIPTION
Refs #259.

This doesn’t resolve the server side issue with the validator, because I’m not sure how to fix that. I think the problem is around here:
https://github.com/IATI/ckanext-iati/blob/cd0a6635127982e8eab0939ec7b2f695e3166da1/ckanext/iati/logic/validators.py#L210-L213

I suspect the contents of `val` is incorrect here.